### PR TITLE
SS-8112: reject button fix for gumball and code improvement for onCancel

### DIFF
--- a/components/shapediver/parameter/ParameterSelectionComponent.tsx
+++ b/components/shapediver/parameter/ParameterSelectionComponent.tsx
@@ -35,6 +35,7 @@ export default function ParameterSelectionComponent(props: PropsParameter) {
 	const {
 		definition,
 		handleChange,
+		setOnCancelCallback,
 		onCancel,
 		disabled,
 		value,
@@ -168,13 +169,16 @@ export default function ParameterSelectionComponent(props: PropsParameter) {
 		</Button>;
 
 	// extend the onCancel callback to reset the selected node names.
-	const _onCancel = useMemo(() => onCancel ? () =>{
+	const _onCancelCallback = useCallback(() => {
 		resetSelection(state.execValue);
-		onCancel?.();
-	} : undefined, [onCancel]);
+	}, []);
+
+	useEffect(() => {
+		setOnCancelCallback(() => _onCancelCallback);
+	}, [_onCancelCallback]);
 
 	return <>
-		<ParameterLabelComponent {...props} cancel={_onCancel} />
+		<ParameterLabelComponent {...props} cancel={onCancel} />
 		{
 			definition &&
 			selectionActive ? contentActive : contentInactive

--- a/hooks/shapediver/parameters/useParameterComponentCommons.ts
+++ b/hooks/shapediver/parameters/useParameterComponentCommons.ts
@@ -43,14 +43,20 @@ export function useParameterComponentCommons<T>(
 		setValue(state.uiValue);
 	}, [state.uiValue]);
 
+	// state for the onCancel callback which can be set from the parameter components
+	const [onCancelCallback, setOnCancelCallback] = useState<(() => void) | undefined>(undefined);
+
 	/**
 	 * Provide a possibility to cancel if
 	 *   - the component is running in acceptRejectMode and the parameter state is dirty, AND
 	 *   - changes are not currently executing
 	 */
 	const onCancel = useMemo( () => acceptRejectMode && state.dirty && !executing ? 
-		() => handleChange(state.execValue, 0) : undefined,
-	[acceptRejectMode, state.dirty, executing, state.execValue] );
+		() => {
+			onCancelCallback?.();
+			handleChange(state.execValue, 0);
+		} : undefined,
+	[acceptRejectMode, state.dirty, executing, state.execValue, onCancelCallback] );
 
 	/** 
 	 * disable the component in case 
@@ -70,6 +76,7 @@ export function useParameterComponentCommons<T>(
 		value,
 		setValue,
 		handleChange,
+		setOnCancelCallback,
 		onCancel,
 		disabled
 	};


### PR DESCRIPTION
https://shapediver.atlassian.net/browse/SS-8112

@snabela small note on the difference in behavior for the gumball and selection. In the gumball, the assigned value is internally completely reset, as the transformations come from GH after a customization update.