### PR TITLE
SS-8091: generalization of useNodeInteractionData

### DIFF
--- a/components/shapediver/parameter/ParameterSelectionComponent.tsx
+++ b/components/shapediver/parameter/ParameterSelectionComponent.tsx
@@ -55,7 +55,7 @@ export default function ParameterSelectionComponent(props: PropsParameter) {
 	// get the viewport ID
 	const { viewportId } = useViewportId();
 	
-	const { selectedNodeNames, setSelectedNodeNames } = useSelection(
+	const { selectedNodeNames, setSelectedNodeNames, nodeInteractionDataHandlers } = useSelection(
 		sessionDependencies, 
 		viewportId, 
 		selectionProps,
@@ -192,6 +192,7 @@ export default function ParameterSelectionComponent(props: PropsParameter) {
 	}, [_onCancelCallback]);
 
 	return <>
+		<>{nodeInteractionDataHandlers}</>
 		<ParameterLabelComponent {...props} cancel={onCancel} />
 		{
 			definition &&

--- a/hooks/shapediver/viewer/interaction/gumball/useGumball.ts
+++ b/hooks/shapediver/viewer/interaction/gumball/useGumball.ts
@@ -94,8 +94,9 @@ export function useGumball(
 
 	// use an effect to set the selected node names to the first available node name if only one is available
 	useEffect(() => {
-		if(activate && Object.values(availableNodeNames).flat().length === 1) {
-			setSelectedNodeNamesAndRestoreSelection([Object.values(availableNodeNames).flat()[0]]);
+		const singleAvailableNodeName = getSingleAvailableNodeName(availableNodeNames);
+		if(activate && singleAvailableNodeName) {
+			setSelectedNodeNamesAndRestoreSelection([singleAvailableNodeName]);
 		}
 	}, [availableNodeNames, setSelectedNodeNamesAndRestoreSelection]);
 
@@ -211,6 +212,27 @@ const getNodesByName = (sessionApis: ISessionApi[], names: string[]): { name: st
 	}
 
 	return nodes;
+};
+
+/**
+ * Get a single available node name, if there is only one available.
+ * 
+ * @param availableNodeNames 
+ * @returns 
+ */
+const getSingleAvailableNodeName = (availableNodeNames: { [key: string]: { [key: string]: string[] } }): string | undefined => {
+	let availableNodeName: string | undefined = undefined;
+	let count = 0;
+
+	for (const outerObj of Object.values(availableNodeNames)) {
+		for (const arr of Object.values(outerObj)) {
+			count += arr.length;
+			if (count > 1) return;
+			if (arr.length === 1) availableNodeName = arr[0];
+		}
+	}
+
+	return availableNodeName;
 };
 
 // #endregion Functions (1)

--- a/hooks/shapediver/viewer/interaction/selection/useSelectManagerEvents.ts
+++ b/hooks/shapediver/viewer/interaction/selection/useSelectManagerEvents.ts
@@ -35,7 +35,7 @@ export interface ISelectionState {
  * 					Note that this initial state is not checked against the filter pattern.
  */
 export function useSelectManagerEvents(
-	patterns: OutputNodeNameFilterPatterns, 
+	patterns: { [key: string]: OutputNodeNameFilterPatterns }, 
 	componentId: string,
 	initialSelectedNodeNames?: string[]
 ): ISelectionState {
@@ -62,7 +62,11 @@ export function useSelectManagerEvents(
 			if (selectEvent.manager.id !== componentId) return;
 
 			const selected = [selectEvent.node];
-			const nodeNames = matchNodesWithPatterns(patterns, selected);
+			const nodeNames = [];
+			for(const sessionId in patterns) {
+				const pattern = patterns[sessionId];
+				nodeNames.push(...matchNodesWithPatterns(pattern, selected));
+			}
 			setSelectedNodeNames(nodeNames);
 		});
 
@@ -98,7 +102,11 @@ export function useSelectManagerEvents(
 			if (multiSelectEvent.manager.id !== componentId) return;
 
 			const selected = multiSelectEvent.nodes;
-			const nodeNames = matchNodesWithPatterns(patterns, selected);
+			const nodeNames = [];
+			for(const sessionId in patterns) {
+				const pattern = patterns[sessionId];
+				nodeNames.push(...matchNodesWithPatterns(pattern, selected));
+			}
 			setSelectedNodeNames(nodeNames);
 		});
 
@@ -116,7 +124,11 @@ export function useSelectManagerEvents(
 
 			// remove the node from the selected nodes
 			const selected = multiSelectEvent.nodes;
-			const nodeNames = matchNodesWithPatterns(patterns, selected);
+			const nodeNames = [];
+			for(const sessionId in patterns) {
+				const pattern = patterns[sessionId];
+				nodeNames.push(...matchNodesWithPatterns(pattern, selected));
+			}
 			setSelectedNodeNames(nodeNames);
 		});
 


### PR DESCRIPTION
https://shapediver.atlassian.net/browse/SS-8091

@snabela I fixed the issue of the strict assignment of the loop length with this PR. Please have a look first into the useNodeInteractionData file where you can now see a separate way to call the hook. With this, we can create a single component per call and can even return the data of the hook with the form of a setState callback. Only important thing, these components have to be added to the dom (see ParameterSelectionComponent changes).

There are also some other changes in this commit to handle multiple sessions in a better way. Potentially there could have been issues if there are outputs with the same names in other sessions (as we never had the use case of something like that, it's obviously not an issue).

please don't merge it yet as it depends on the latest viewer version which is still a RC