### PR TITLE
SS-8365: viewport icons in top middle on mobile

### DIFF
--- a/components/shapediver/ui/OverlayWrapper.tsx
+++ b/components/shapediver/ui/OverlayWrapper.tsx
@@ -1,10 +1,13 @@
 import React, { useMemo } from "react";
+import { ResponsiveValueType, useResponsiveValueSelector } from "shared/hooks/ui/useResponsiveValueSelector";
 
 export const OverlayPosition = {
 	TOP_LEFT: "top-left",
 	TOP_RIGHT: "top-right",
 	BOTTOM_LEFT: "bottom-left",
 	BOTTOM_RIGHT: "bottom-right",
+	TOP_MIDDLE: "top-middle",
+	BOTTOM_MIDDLE: "bottom-middle",
 } as const;
 
 export type OverlayPositionType = typeof OverlayPosition[keyof typeof OverlayPosition];
@@ -27,6 +30,16 @@ function getPositionStyles(offset: string | number = 0) {
 			bottom: `${offset}`,
 			right: `${offset}`,
 		},
+		[OverlayPosition.TOP_MIDDLE]: {
+			top: `${offset}`,
+			left: "50%",
+			transform: "translateX(-50%)",
+		},
+		[OverlayPosition.BOTTOM_MIDDLE]: {
+			bottom: `${offset}`,
+			left: "50%",
+			transform: "translateX(-50%)",
+		},
 	};
 }
 
@@ -35,7 +48,7 @@ interface Props {
 }
 
 export interface OverlayStyleProps {
-	position: OverlayPositionType;
+	position: ResponsiveValueType<OverlayPositionType>;
 	offset?: string;
 }
 
@@ -43,11 +56,13 @@ export default function OverlayWrapper(props: Props & Partial<OverlayStyleProps>
 
 	const { 
 		children = <></>, 
-		position = OverlayPosition.TOP_LEFT,
+		position: _position = OverlayPosition.TOP_LEFT,
 		offset,
 	} = props;
 
 	const positionStyles = useMemo(() => getPositionStyles(offset), [offset]);
+
+	const position = useResponsiveValueSelector(_position);
 	
 	return <section style={{...positionStyles[position], position: "absolute"}}>
 		{ children }

--- a/components/shapediver/viewport/ViewportOverlayWrapper.tsx
+++ b/components/shapediver/viewport/ViewportOverlayWrapper.tsx
@@ -4,7 +4,10 @@ import OverlayWrapper, { OverlayStyleProps, OverlayPosition } from "../ui/Overla
 import { ViewportOverlayWrapperProps } from "shared/types/shapediver/viewportOverlayWrapper";
 
 const defaultStyleProps: OverlayStyleProps = {
-	position: OverlayPosition.TOP_RIGHT,
+	position: {
+		base: OverlayPosition.TOP_MIDDLE,
+		md: OverlayPosition.TOP_RIGHT,
+	},
 };
 
 export default function ViewportOverlayWrapper(props: ViewportOverlayWrapperProps & Partial<OverlayStyleProps>) {


### PR DESCRIPTION
https://shapediver.atlassian.net/browse/SS-8365

Small change from the description in the task (I'm not sure if you meant it that way or not), I implemented the useResponsiveValueSelector in the OverlayWrapper. 

Works as expected!