### PR TITLE
SS-8727: fixed issue with subscribe function

### DIFF
--- a/store/useShapeDiverStoreSession.ts
+++ b/store/useShapeDiverStoreSession.ts
@@ -258,6 +258,10 @@ export const useShapeDiverStoreSession = create<IShapeDiverStoreSession>()(
 					if (!newOutputUpdateCallbacks[sessionId][outputId])
 						newOutputUpdateCallbacks[sessionId][outputId] = {};
 
+					newOutputUpdateCallbacks[sessionId] = {
+						...newOutputUpdateCallbacks[sessionId],
+					};
+
 					newOutputUpdateCallbacks[sessionId][outputId] = {
 						...newOutputUpdateCallbacks[sessionId][outputId],
 						[callbackId]: updateCallback,


### PR DESCRIPTION
https://shapediver.atlassian.net/browse/SS-8727

not an issue with zustand but with object nesting
as the nested object was not re-created, the prevState was already updated in the subscribe function
This only happened here because the state updates are called in a loop without breaking the javascript event loop