### PR TITLE
SS-8748: use current jwtToken of the session

### DIFF
--- a/hooks/shapediver/useSession.ts
+++ b/hooks/shapediver/useSession.ts
@@ -117,7 +117,6 @@ export function useSession(props: IUseSessionDto | undefined) {
 					// in case the session definition defines acceptRejectMode, use it
 					// otherwise fall back to acceptRejectMode defined by the viewer settings
 					acceptRejectMode ?? api.commitParameters,
-					props.jwtToken,
 					eventTracking,
 				);
 			}

--- a/hooks/shapediver/useSessions.ts
+++ b/hooks/shapediver/useSessions.ts
@@ -76,7 +76,6 @@ export function useSessions(props: IUseSessionDto[]) {
 						// in case the session definition defines acceptRejectMode, use it
 						// otherwise fall back to acceptRejectMode defined by the viewer settings
 						dto.acceptRejectMode ?? api.commitParameters,
-						dto.jwtToken,
 						eventTracking,
 					);
 				}

--- a/store/useShapeDiverStoreParameters.ts
+++ b/store/useShapeDiverStoreParameters.ts
@@ -554,11 +554,7 @@ function mapExportDefinition(
 /**
  * Create store for a single export.
  */
-function createExportStore(
-	session: ISessionApi,
-	exportId: string,
-	token?: string,
-) {
+function createExportStore(session: ISessionApi, exportId: string) {
 	const exportApi = session.exports[exportId];
 	/** The static definition of the export. */
 	const definition = mapExportDefinition(exportApi);
@@ -585,7 +581,9 @@ function createExportStore(
 			},
 			fetch: async (url: string) => {
 				return fetch(url, {
-					...(token ? {headers: {Authorization: token}} : {}),
+					...(session.jwtToken
+						? {headers: {Authorization: session.jwtToken}}
+						: {}),
 				});
 			},
 		},
@@ -844,7 +842,6 @@ export const useShapeDiverStoreParameters =
 				addSession: (
 					session: ISessionApi,
 					_acceptRejectMode: boolean | IAcceptRejectModeSelector,
-					token?: string,
 					callbacks?: IEventTracking,
 				) => {
 					const sessionId = session.id;
@@ -965,7 +962,6 @@ export const useShapeDiverStoreParameters =
 													createExportStore(
 														session,
 														exportId,
-														token,
 													);
 
 												return acc;

--- a/types/store/shapediverStoreParameters.ts
+++ b/types/store/shapediverStoreParameters.ts
@@ -249,14 +249,12 @@ export interface IShapeDiverStoreParameters {
 	 * calling addSession again for the same session.
 	 * @param session
 	 * @param acceptRejectMode If true, changes are not executed immediately. May be specified as a boolean or a function of the parameter definition.
-	 * @param token Token (JWT) that was used when creating the session. If provided, it will be used for export downloads. Optional.
 	 * @param callbacks Callbacks. Optional.
 	 * @returns
 	 */
 	readonly addSession: (
 		session: ISessionApi,
 		acceptRejectMode: boolean | IAcceptRejectModeSelector,
-		token?: string,
 		callbacks?: IShapeDiverStoreParametersCallbacks,
 	) => void;
 


### PR DESCRIPTION
https://shapediver.atlassian.net/browse/SS-8748

The issue was only in App Builder as there is a separate fetch function that always used the original token. So after the token was re-newed, the old token was still used for fetching.

I'm creatin a PR here, because I'm not sure why we use this fetching function in the first place. Is there a reason for it?
fetchFileWithToken can also receive a token to use