### PR TITLE
SS-8545: Add anchor elements when an object is clicked in AV mode

### DIFF
--- a/components/shapediver/appbuilder/widgets/AppBuilderAttributeVisualizationWidgetComponent.tsx
+++ b/components/shapediver/appbuilder/widgets/AppBuilderAttributeVisualizationWidgetComponent.tsx
@@ -1,5 +1,6 @@
 import TooltipWrapper from "@AppBuilderShared/components/ui/TooltipWrapper";
 import {useAttributeOverview} from "@AppBuilderShared/hooks/shapediver/viewer/attributeVisualization/useAttributeOverview";
+import useAttributeSelection from "@AppBuilderShared/hooks/shapediver/viewer/attributeVisualization/useAttributeSelection";
 import {useAttributeVisualizationEngine} from "@AppBuilderShared/hooks/shapediver/viewer/attributeVisualization/useAttributeVisualizationEngine";
 import {useAttributeWidgetVisibilityTracker} from "@AppBuilderShared/hooks/shapediver/viewer/attributeVisualization/useAttributeWidgetVisibilityTracker";
 import {
@@ -45,6 +46,8 @@ import {
 import {IViewportApi} from "@shapediver/viewer.viewport";
 import {IconEye, IconEyeOff} from "@tabler/icons-react";
 import React, {useCallback, useEffect, useId, useMemo, useState} from "react";
+import SelectedAttributeComponent from "../../ui/SelectedAttributeComponent";
+import ViewportAnchor from "../../viewport/ViewportAnchor";
 import ColorAttribute from "./attributes/ColorAttribute";
 import DefaultAttribute, {
 	IDefaultAttributeExtended,
@@ -54,7 +57,7 @@ import NumberAttribute, {
 } from "./attributes/NumberAttribute";
 import StringAttribute from "./attributes/StringAttribute";
 
-type IAttributeDefinition =
+export type IAttributeDefinition =
 	| IAttribute
 	| INumberAttributeExtended
 	| IStringAttribute
@@ -166,6 +169,12 @@ export default function AppBuilderAttributeVisualizationWidgetComponent(
 		attributeOverview,
 		propsAttributes,
 	);
+	const attributeSelectionData = useAttributeSelection(
+		viewportId,
+		active,
+		renderedAttribute,
+	);
+
 	/**
 	 *
 	 *
@@ -674,6 +683,22 @@ export default function AppBuilderAttributeVisualizationWidgetComponent(
 					</Stack>
 				</Paper>
 			</TooltipWrapper>
+			{attributeSelectionData && (
+				<ViewportAnchor
+					location={attributeSelectionData.location}
+					id={`${widgetId}_anchor`}
+					element={
+						<SelectedAttributeComponent
+							renderedAttribute={renderedAttribute}
+							attributes={attributes}
+							selectedItemData={
+								attributeSelectionData.selectedItemData
+							}
+							handleAttributeChange={handleAttributeChange}
+						/>
+					}
+				/>
+			)}
 		</>
 	);
 }

--- a/components/shapediver/appbuilder/widgets/AppBuilderAttributeVisualizationWidgetComponent.tsx
+++ b/components/shapediver/appbuilder/widgets/AppBuilderAttributeVisualizationWidgetComponent.tsx
@@ -683,7 +683,7 @@ export default function AppBuilderAttributeVisualizationWidgetComponent(
 					</Stack>
 				</Paper>
 			</TooltipWrapper>
-			{attributeSelectionData && (
+			{active && attributeSelectionData && (
 				<ViewportAnchor
 					location={attributeSelectionData.location}
 					id={`${widgetId}_anchor`}

--- a/components/shapediver/ui/SelectedAttributeComponent.module.css
+++ b/components/shapediver/ui/SelectedAttributeComponent.module.css
@@ -1,0 +1,10 @@
+.selectedAttributeTd {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.selectedAttributeTd:hover {
+  overflow: visible !important;
+  white-space: normal !important;
+}

--- a/components/shapediver/ui/SelectedAttributeComponent.tsx
+++ b/components/shapediver/ui/SelectedAttributeComponent.tsx
@@ -1,0 +1,206 @@
+import Icon from "@AppBuilderShared/components/ui/Icon";
+import {Attributes} from "@AppBuilderShared/hooks/shapediver/viewer/attributeVisualization/useConvertAttributeInputData";
+import {IconTypeEnum} from "@AppBuilderShared/types/shapediver/icons";
+import {ActionIcon, Stack, Table} from "@mantine/core";
+import {ISDTFAttributeData} from "@shapediver/viewer.session";
+import React, {useMemo} from "react";
+import {IAttributeDefinition} from "../appbuilder/widgets/AppBuilderAttributeVisualizationWidgetComponent";
+import classes from "./SelectedAttributeComponent.module.css";
+
+type Props = {
+	attributes?: Attributes;
+	selectedItemData?: {
+		[key: string]: ISDTFAttributeData;
+	};
+	renderedAttribute?: IAttributeDefinition;
+	handleAttributeChange?: (attributeId: string) => void;
+};
+
+type SelectedAttributeData = {
+	[key: string]: {
+		value: string;
+		typeHint: string;
+		ableToActivate: boolean;
+		currentlyActive: boolean;
+	};
+};
+
+export default function SelectedAttributeComponent(props: Props) {
+	const {
+		attributes,
+		selectedItemData,
+		renderedAttribute,
+		handleAttributeChange,
+	} = props;
+
+	/**
+	 * Create the attribute data to show in the table.
+	 * If no attributes are provided, we show all attributes from the selected item data.
+	 * If attributes are provided, we only show the attributes that are in the attributes array.
+	 * We also check if the rendered attribute is active and set the currentlyActive property accordingly
+	 * which results in the eye icon being shown in the last column.
+	 */
+	const attributeDataToShow: SelectedAttributeData = useMemo(() => {
+		if (!selectedItemData) return {};
+		// If no attributes are provided, we show all attributes from the selected item data.
+		if (!attributes) {
+			// show them all
+			// as we don't know which attributes are specified, we set the ableToActivate property to false
+			return Object.entries(selectedItemData).reduce(
+				(acc, [key, value]) => {
+					acc[key] = {
+						value: JSON.stringify(value.value),
+						typeHint: value.typeHint,
+						ableToActivate: false,
+						currentlyActive:
+							renderedAttribute?.key === key &&
+							renderedAttribute?.type === value.typeHint,
+					};
+					return acc;
+				},
+				{} as SelectedAttributeData,
+			);
+		}
+		// If attributes are provided, we only show the attributes that are in the attributes array of the selected item.
+		// We also check if the rendered attribute is active and set the currentlyActive property accordingly
+		// which results in the eye icon being shown in the last column.
+		const attributeKeys = attributes
+			.map((attribute) => {
+				const realKey =
+					typeof attribute === "string"
+						? getAttributeKey(attribute, selectedItemData)
+						: getAttributeKey(
+								attribute.attribute,
+								selectedItemData,
+							);
+				if (!realKey) return undefined;
+				const value = selectedItemData[realKey];
+				if (!value) return undefined;
+				// as we know that these attributes are specified, we can set the ableToActivate property to true
+				// and the currentlyActive property based on the rendered attribute
+				return {
+					[realKey]: {
+						value: JSON.stringify(value.value),
+						typeHint: value.typeHint,
+						ableToActivate: true,
+						currentlyActive:
+							renderedAttribute?.key === realKey &&
+							renderedAttribute?.type === value.typeHint,
+					},
+				};
+			})
+			.filter((key) => key !== undefined)
+			.reduce((acc, curr) => {
+				return {...acc, ...curr};
+			}, {} as SelectedAttributeData);
+		return attributeKeys;
+	}, [attributes, renderedAttribute, selectedItemData]);
+
+	/**
+	 * Create the rows for the table.
+	 * We map over the attributeDataToShow and create a row for each attribute.
+	 * In the row, we show the key, the value and an eye icon if the attribute is able to be activated.
+	 * If the attribute is currently active, we show the eye icon, otherwise we show an ActionIcon to activate it.
+	 */
+	const rows = Object.entries(attributeDataToShow).map(([key, value]) => (
+		<Table.Tr
+			key={key}
+			bg={
+				value.currentlyActive
+					? "var(--mantine-primary-color-light)"
+					: undefined
+			}
+		>
+			<Table.Td className={classes.selectedAttributeTd}>{key}</Table.Td>
+			<Table.Td className={classes.selectedAttributeTd}>
+				{JSON.stringify(value.value)}
+			</Table.Td>
+			{value.ableToActivate && (
+				<Table.Td align="center">
+					{value.currentlyActive ? (
+						<Icon type={IconTypeEnum.Eye} />
+					) : (
+						<ActionIcon
+							title="Toggle Layer"
+							size={"sm"}
+							onClick={() => {
+								if (!handleAttributeChange) return;
+								handleAttributeChange(
+									key + "_" + value.typeHint,
+								);
+							}}
+							variant={"light"}
+						>
+							<Icon type={IconTypeEnum.EyeOff} />
+						</ActionIcon>
+					)}
+				</Table.Td>
+			)}
+		</Table.Tr>
+	));
+
+	return (
+		<>
+			{selectedItemData && (
+				<Stack>
+					<Table
+						style={{tableLayout: "fixed", width: "100%"}}
+						highlightOnHover
+					>
+						<Table.Thead>
+							<Table.Tr>
+								<Table.Th style={{width: "25%"}}>Name</Table.Th>
+								<Table.Th style={{width: "auto"}}>
+									Value
+								</Table.Th>
+								{Object.values(attributeDataToShow).filter(
+									(v) => v.ableToActivate,
+								).length > 0 && (
+									<Table.Th style={{width: "15%"}}>
+										Show
+									</Table.Th>
+								)}
+							</Table.Tr>
+						</Table.Thead>
+						<Table.Tbody>{rows}</Table.Tbody>
+					</Table>
+				</Stack>
+			)}
+		</>
+	);
+}
+
+/**
+ * Helper function to get the real key of an attribute from its id.
+ * This is needed because the id can contain a type hint at the end, which is not part of the key in the selectedItemData.
+ *
+ * @param id The id of the attribute to get the key for.
+ * @param data The data to search in.
+ * @returns
+ */
+const getAttributeKey = (
+	id: string,
+	data?: {[key: string]: ISDTFAttributeData},
+): string | undefined => {
+	if (!data) return undefined;
+	if (data[id]) {
+		return id;
+	} else {
+		const parts = id.split("_");
+		if (parts.length > 1) {
+			// remove the last part of the attributeId
+			// this is the type hint, which is not needed for the comparison
+			const typeHint = parts.pop();
+			// recombine the party in case of underscores in the key
+			const attributeKey = parts.join("_");
+
+			if (
+				data[attributeKey] &&
+				data[attributeKey].typeHint === typeHint
+			) {
+				return attributeKey;
+			}
+		}
+	}
+	return undefined;
+};

--- a/components/shapediver/ui/SelectedAttributeComponent.tsx
+++ b/components/shapediver/ui/SelectedAttributeComponent.tsx
@@ -49,7 +49,7 @@ export default function SelectedAttributeComponent(props: Props) {
 			return Object.entries(selectedItemData).reduce(
 				(acc, [key, value]) => {
 					acc[key] = {
-						value: JSON.stringify(value.value),
+						value: value.value as string,
 						typeHint: value.typeHint,
 						ableToActivate: false,
 						currentlyActive:
@@ -80,7 +80,7 @@ export default function SelectedAttributeComponent(props: Props) {
 				// and the currentlyActive property based on the rendered attribute
 				return {
 					[realKey]: {
-						value: JSON.stringify(value.value),
+						value: value.value as string,
 						typeHint: value.typeHint,
 						ableToActivate: true,
 						currentlyActive:

--- a/hooks/shapediver/viewer/attributeVisualization/useAttributeSelection.ts
+++ b/hooks/shapediver/viewer/attributeVisualization/useAttributeSelection.ts
@@ -1,0 +1,298 @@
+import {IAttributeDefinition} from "@AppBuilderShared/components/shapediver/appbuilder/widgets/AppBuilderAttributeVisualizationWidgetComponent";
+import {useSelection} from "@AppBuilderShared/hooks/shapediver/viewer/interaction/selection/useSelection";
+import {useShapeDiverStoreSession} from "@AppBuilderShared/store/useShapeDiverStoreSession";
+import {getNodesByName} from "@shapediver/viewer.features.interaction";
+import {
+	ISDTFAttributeData,
+	ITreeNode,
+	SDTFItemData,
+	SessionApiData,
+} from "@shapediver/viewer.session";
+import {vec3} from "gl-matrix";
+import {useCallback, useEffect, useMemo, useState} from "react";
+
+export type AttributeSelectionData = {
+	selectedItemData: {
+		[key: string]: ISDTFAttributeData;
+	};
+	location: vec3;
+};
+
+/**
+ * Component to be able to select objects with attribute data in the viewer.
+ *
+ * @param props
+ * @returns
+ */
+export default function useAttributeSelection(
+	viewportId: string,
+	active: boolean,
+	renderedAttribute?: IAttributeDefinition,
+): AttributeSelectionData | undefined {
+	const sessions = useShapeDiverStoreSession((state) => state.sessions);
+
+	const [nameFilter, setNameFilter] = useState<{[key: string]: string[]}>({});
+	const [attributeSelectionData, setAttributeSelectionData] = useState<
+		AttributeSelectionData | undefined
+	>();
+	const {addSessionUpdateCallback} = useShapeDiverStoreSession();
+
+	/**
+	 * Whenever the session is updated, the name filter is updated as well.
+	 * We search for all nodes that have an SDTFItemData and add the name of the node to the name filter.
+	 */
+	const sessionCallback = useCallback(
+		(newNode?: ITreeNode) => {
+			if (!newNode) return;
+
+			const sessionApi = (
+				newNode.data.find(
+					(data) => data instanceof SessionApiData,
+				) as SessionApiData
+			).api;
+			if (!sessionApi) return;
+
+			const nameFilterPerSession: string[] = [];
+			newNode.traverse((node) => {
+				if (!renderedAttribute) return;
+				for (const data of node.data) {
+					if (data instanceof SDTFItemData) {
+						// separate criteria if the current selected attribute is present in the item data
+						// if the item data is not present, we can skip this node
+						if (
+							Object.entries(data.attributes).some(
+								([key, value]) =>
+									renderedAttribute.key === key &&
+									renderedAttribute.type === value.typeHint,
+							)
+						) {
+							// get the name of the node and add it to the name filter
+							const path = node.getPath().split(".");
+							// remove the first two elements of the path, because they are the root and session name
+							// we might get here before the session is even added to the root, so we check for that
+							if (path[0] === "root") path.shift();
+							path.shift();
+							// replace the first element of the path with the output name
+							const outputApi = sessionApi.outputs[path[0]];
+							if (!outputApi) continue;
+							path[0] = outputApi.name;
+							nameFilterPerSession.push(path.join("."));
+						}
+					}
+				}
+			});
+
+			setNameFilter((prev) => {
+				const newFilter = {...prev};
+				newFilter[sessionApi.id] = nameFilterPerSession;
+
+				return newFilter;
+			});
+		},
+		[sessions, renderedAttribute],
+	);
+
+	/**
+	 * Use effect to add / remove the session update callbacks.
+	 */
+	useEffect(() => {
+		const removeSessionUpdateCallbacks = Object.keys(sessions).map(
+			(sessionId) => addSessionUpdateCallback(sessionId, sessionCallback),
+		);
+
+		return () => {
+			removeSessionUpdateCallbacks.forEach(
+				(removeSessionUpdateCallback) => {
+					removeSessionUpdateCallback();
+				},
+			);
+		};
+	}, [sessions, sessionCallback]);
+
+	/**
+	 * Create the selection properties for the selection hook with the new name filter.
+	 */
+	const selectionProps = useMemo(() => {
+		return {
+			maximumSelection: 1,
+			minimumSelection: 1,
+			nameFilter: Object.values(nameFilter).flat(),
+			selectionColor: "#0d44f0",
+			hover: true,
+			hoverColor: "#00ff78",
+		};
+	}, [nameFilter]);
+
+	const {selectedNodeNames} = useSelection(
+		viewportId,
+		selectionProps,
+		active,
+		undefined,
+		false,
+	);
+
+	/**
+	 * Whenever the selected nodes change, we check if the node has an SDTFItemData.
+	 * If it does, we set the attribute selection data to the attributes of the SDTFItemData.
+	 */
+	useEffect(() => {
+		if (selectedNodeNames.length > 0) {
+			const nodes = getNodesByName(
+				Object.values(sessions),
+				selectedNodeNames,
+				false,
+			);
+			if (nodes.length > 0) {
+				const node = nodes[0].node;
+				const sdtfItemData = node.data.find(
+					(data) => data instanceof SDTFItemData,
+				);
+				if (sdtfItemData) {
+					setAttributeSelectionData({
+						selectedItemData: sdtfItemData.attributes,
+						location: node.boundingBox.boundingSphere.center,
+					});
+					return;
+				}
+			}
+		}
+
+		setAttributeSelectionData(undefined);
+	}, [selectedNodeNames]);
+
+	return attributeSelectionData;
+}
+
+/**
+	return (
+		<>
+			{selectedItemData && (
+				<Stack>
+					<Group
+						justify="space-between"
+						onClick={() => setOpened((t) => !t)}
+					>
+						<Title order={5}> Selected Item </Title>
+						{opened ? <IconChevronUp /> : <IconChevronDown />}
+					</Group>
+					{opened && (
+						<Table highlightOnHover withTableBorder>
+							<Table.Thead>
+								<Table.Tr bg={"var(--table-hover-color)"}>
+									<Table.Th
+										style={{
+											width: "20%",
+											whiteSpace: "nowrap",
+										}}
+									>
+										Name
+									</Table.Th>
+									<Table.Th style={{width: "100%"}}>
+										Value
+									</Table.Th>
+									<Table.Th
+										style={{
+											width: "auto",
+											whiteSpace: "nowrap",
+										}}
+									>
+										Show
+									</Table.Th>
+								</Table.Tr>
+							</Table.Thead>
+							<Table.Tbody>
+								{Object.entries(selectedItemData).map(
+									([key, value]) => (
+										<Table.Tr
+											key={key}
+											bg={
+												selectedValues.find(
+													(s) =>
+														s.name === key &&
+														s.type ===
+															value.typeHint,
+												)
+													? "var(--mantine-primary-color-light)"
+													: undefined
+											}
+										>
+											<Table.Td>{key}</Table.Td>
+											<Table.Td>
+												{JSON.stringify(
+													selectedItemData[key].value,
+												)}
+											</Table.Td>
+											<Table.Td align="center">
+												<ActionIcon
+													title="Toggle Layer"
+													size={"sm"}
+													onClick={() => {
+														if (
+															selectedValues.find(
+																(s) =>
+																	s.name ===
+																		key &&
+																	s.type ===
+																		value.typeHint,
+															)
+														) {
+															removeAttribute(
+																key,
+																value.typeHint,
+															);
+														} else {
+															setSelectedValues(
+																(prev) => [
+																	...prev,
+																	{
+																		name: key,
+																		type: value.typeHint,
+																	},
+																],
+															);
+														}
+													}}
+													variant={
+														selectedValues.find(
+															(s) =>
+																s.name ===
+																	key &&
+																s.type ===
+																	value.typeHint,
+														)
+															? "filled"
+															: "light"
+													}
+												>
+													{selectedValues.find(
+														(s) =>
+															s.name === key &&
+															s.type ===
+																value.typeHint,
+													) ? (
+														<Icon
+															type={
+																IconTypeEnum.EyeOff
+															}
+														/>
+													) : (
+														<Icon
+															type={
+																IconTypeEnum.Eye
+															}
+														/>
+													)}
+												</ActionIcon>
+											</Table.Td>
+										</Table.Tr>
+									),
+								)}
+							</Table.Tbody>
+						</Table>
+					)}
+				</Stack>
+			)}
+		</>
+	);
+}
+    */

--- a/hooks/shapediver/viewer/attributeVisualization/useAttributeSelection.ts
+++ b/hooks/shapediver/viewer/attributeVisualization/useAttributeSelection.ts
@@ -8,14 +8,13 @@ import {
 	SDTFItemData,
 	SessionApiData,
 } from "@shapediver/viewer.session";
-import {vec3} from "gl-matrix";
 import {useCallback, useEffect, useMemo, useState} from "react";
 
 export type AttributeSelectionData = {
 	selectedItemData: {
 		[key: string]: ISDTFAttributeData;
 	};
-	location: vec3;
+	location: number[];
 };
 
 /**
@@ -150,7 +149,11 @@ export default function useAttributeSelection(
 				if (sdtfItemData) {
 					setAttributeSelectionData({
 						selectedItemData: sdtfItemData.attributes,
-						location: node.boundingBox.boundingSphere.center,
+						location: [
+							node.boundingBox.boundingSphere.center[0],
+							node.boundingBox.boundingSphere.center[1],
+							node.boundingBox.boundingSphere.center[2],
+						],
 					});
 					return;
 				}
@@ -162,137 +165,3 @@ export default function useAttributeSelection(
 
 	return attributeSelectionData;
 }
-
-/**
-	return (
-		<>
-			{selectedItemData && (
-				<Stack>
-					<Group
-						justify="space-between"
-						onClick={() => setOpened((t) => !t)}
-					>
-						<Title order={5}> Selected Item </Title>
-						{opened ? <IconChevronUp /> : <IconChevronDown />}
-					</Group>
-					{opened && (
-						<Table highlightOnHover withTableBorder>
-							<Table.Thead>
-								<Table.Tr bg={"var(--table-hover-color)"}>
-									<Table.Th
-										style={{
-											width: "20%",
-											whiteSpace: "nowrap",
-										}}
-									>
-										Name
-									</Table.Th>
-									<Table.Th style={{width: "100%"}}>
-										Value
-									</Table.Th>
-									<Table.Th
-										style={{
-											width: "auto",
-											whiteSpace: "nowrap",
-										}}
-									>
-										Show
-									</Table.Th>
-								</Table.Tr>
-							</Table.Thead>
-							<Table.Tbody>
-								{Object.entries(selectedItemData).map(
-									([key, value]) => (
-										<Table.Tr
-											key={key}
-											bg={
-												selectedValues.find(
-													(s) =>
-														s.name === key &&
-														s.type ===
-															value.typeHint,
-												)
-													? "var(--mantine-primary-color-light)"
-													: undefined
-											}
-										>
-											<Table.Td>{key}</Table.Td>
-											<Table.Td>
-												{JSON.stringify(
-													selectedItemData[key].value,
-												)}
-											</Table.Td>
-											<Table.Td align="center">
-												<ActionIcon
-													title="Toggle Layer"
-													size={"sm"}
-													onClick={() => {
-														if (
-															selectedValues.find(
-																(s) =>
-																	s.name ===
-																		key &&
-																	s.type ===
-																		value.typeHint,
-															)
-														) {
-															removeAttribute(
-																key,
-																value.typeHint,
-															);
-														} else {
-															setSelectedValues(
-																(prev) => [
-																	...prev,
-																	{
-																		name: key,
-																		type: value.typeHint,
-																	},
-																],
-															);
-														}
-													}}
-													variant={
-														selectedValues.find(
-															(s) =>
-																s.name ===
-																	key &&
-																s.type ===
-																	value.typeHint,
-														)
-															? "filled"
-															: "light"
-													}
-												>
-													{selectedValues.find(
-														(s) =>
-															s.name === key &&
-															s.type ===
-																value.typeHint,
-													) ? (
-														<Icon
-															type={
-																IconTypeEnum.EyeOff
-															}
-														/>
-													) : (
-														<Icon
-															type={
-																IconTypeEnum.Eye
-															}
-														/>
-													)}
-												</ActionIcon>
-											</Table.Td>
-										</Table.Tr>
-									),
-								)}
-							</Table.Tbody>
-						</Table>
-					)}
-				</Stack>
-			)}
-		</>
-	);
-}
-    */

--- a/hooks/shapediver/viewer/interaction/selection/useSelection.tsx
+++ b/hooks/shapediver/viewer/interaction/selection/useSelection.tsx
@@ -179,6 +179,14 @@ export function useSelection(
 			});
 		}
 
+		// if the selected node names are the same, we don't need to update the state
+		if (
+			newSelectedNodeNames.length === selectedNodeNames.length &&
+			newSelectedNodeNames.every((name) =>
+				selectedNodeNames.includes(name),
+			)
+		)
+			return;
 		setSelectedNodeNames(newSelectedNodeNames);
 	}, [availableNodeNames]);
 

--- a/hooks/shapediver/viewer/interaction/selection/useSelection.tsx
+++ b/hooks/shapediver/viewer/interaction/selection/useSelection.tsx
@@ -165,6 +165,23 @@ export function useSelection(
 		return outputs;
 	});
 
+	// when the available node names change, we need to update the selected node names
+	// to ensure that the selected nodes are still available
+	useEffect(() => {
+		const newSelectedNodeNames: string[] = [];
+		if (selectedNodeNames.length > 0 && availableNodeNames) {
+			selectedNodeNames.forEach((name) => {
+				Object.values(availableNodeNames).forEach((availableNames) => {
+					if (availableNames.includes(name)) {
+						newSelectedNodeNames.push(name);
+					}
+				});
+			});
+		}
+
+		setSelectedNodeNames(newSelectedNodeNames);
+	}, [availableNodeNames]);
+
 	// in case selection becomes active or the output node changes, restore the selection status
 	useEffect(() => {
 		if (!selectManager) return;


### PR DESCRIPTION
https://shapediver.atlassian.net/browse/SS-8545

FYI: base for this is the Anchors branch, as it builds on this.
I decided against making this a widget for now as I'm not sure if it would ever get used.

The separation is done by having a hook `useAttributeSelection`, which handles the selection of the attributes depending on certain criteria. This can then also be re-used when we implement a global functionality for clicking on objects and letting people inspect the attribute data (as discussed with Mathieu).

The `SelectedAttributeComponent` is a relatively simple component that puts everything in a table and just has some logic regarding which objects should be shown etc.