### PR TITLE
SS-8827: Add menu item custom colors

### DIFF
--- a/components/shapediver/viewport/buttons/HistoryMenuButton.tsx
+++ b/components/shapediver/viewport/buttons/HistoryMenuButton.tsx
@@ -9,6 +9,7 @@ import {ViewportTransparentBackgroundStyle} from "@AppBuilderShared/types/shaped
 import {ActionIcon, Menu, MenuDropdownProps} from "@mantine/core";
 import React, {useCallback, useContext, useState} from "react";
 import classes from "../ViewportIcons.module.css";
+import iconClasses from "./Icon.module.css";
 import {CommonButtonProps, IconProps} from "./types";
 
 interface HistoryMenuButtonProps extends CommonButtonProps {
@@ -118,8 +119,10 @@ export default function HistoryMenuButton({
 				<Menu.Dropdown {...menuDropdownProps}>
 					{enableResetButton && (
 						<Menu.Item
+							color={IconProps.color}
 							onClick={resetParameters}
 							disabled={disabled || isCreatingModelState}
+							className={iconClasses.menuItem}
 						>
 							Reset to default values
 						</Menu.Item>
@@ -128,14 +131,18 @@ export default function HistoryMenuButton({
 						<>
 							{enableResetButton && <Menu.Divider />}
 							<Menu.Item
+								color={IconProps.color}
 								onClick={importParameters}
 								disabled={disabled || isCreatingModelState}
+								className={iconClasses.menuItem}
 							>
 								Import parameter values
 							</Menu.Item>
 							<Menu.Item
+								color={IconProps.color}
 								onClick={exportParameters}
 								disabled={disabled || isCreatingModelState}
+								className={iconClasses.menuItem}
 							>
 								Export parameter values
 							</Menu.Item>
@@ -146,14 +153,17 @@ export default function HistoryMenuButton({
 							{(enableResetButton ||
 								enableImportExportButtons) && <Menu.Divider />}
 							<Menu.Item
+								color={IconProps.color}
 								onClick={onCreateModelState}
 								disabled={disabled || isCreatingModelState}
+								className={iconClasses.menuItem}
 							>
 								Create model state
 							</Menu.Item>
 							<Menu.Item
 								onClick={() => setIsImportDialogOpen(true)}
 								disabled={disabled || isCreatingModelState}
+								className={iconClasses.menuItem}
 							>
 								Import model state
 							</Menu.Item>

--- a/components/shapediver/viewport/buttons/Icon.module.css
+++ b/components/shapediver/viewport/buttons/Icon.module.css
@@ -1,0 +1,5 @@
+.menuItem {
+    &:hover {
+        background-color: var(--vpi-menu-item-hover, var(--menu-item-hover, var(--mantine-color-gray-1)));
+    }
+}

--- a/components/shapediver/viewport/buttons/types.ts
+++ b/components/shapediver/viewport/buttons/types.ts
@@ -12,6 +12,7 @@ export interface CommonButtonProps {
 export const IconProps = {
 	color: "var(--mantine-color-default-color)",
 	colorDisabled: "var(--mantine-color-disabled-color)",
+	colorHover: "var(--mantine-color-blue-light-hover)",
 	variant: "subtle",
 	variantDisabled: "transparent",
 	size: 32,

--- a/types/shapediver/viewport.ts
+++ b/types/shapediver/viewport.ts
@@ -1,3 +1,4 @@
+import {IconProps} from "@AppBuilderShared/components/shapediver/viewport/buttons/types";
 import {alpha, MantineThemeComponent} from "@mantine/core";
 import {
 	BUSY_MODE_DISPLAY,
@@ -75,7 +76,13 @@ export function ViewportBrandingThemeProps(
 	};
 }
 
-export const ViewportTransparentBackgroundStyle: React.CSSProperties = {
+type ViewportTransparentBackgroundStyleVariables = {
+	"--vpi-menu-item-hover": string;
+};
+
+export const ViewportTransparentBackgroundStyle: React.CSSProperties &
+	ViewportTransparentBackgroundStyleVariables = {
 	backgroundColor: alpha("var(--mantine-color-body)", 0.5),
 	backdropFilter: "blur(10px)",
+	"--vpi-menu-item-hover": IconProps.colorHover,
 };


### PR DESCRIPTION
The problem:
Different Mantine components have different hover background colors.

Examples:

**\<ActionIcon\>**
Uses:
background-color: var(`--ai-hover`, var(`--mantine-primary-color-filled-hover`));
`--ai-hover` is set to:
var(`--mantine-color-blue-light-hover`);

**\<Button\>**
Uses:
background-color: var(`--button-hover`, var(`--mantine-primary-color-filled-hover`));
`--button-hover` is set to:
var(`--mantine-color-default-hover`);

**\<Menu.Item\>**
Uses:
background-color: var(`--menu-item-hover`, var(`--mantine-color-gray-1`));
`--menu-item-hover` is set to:
color-mix(in srgb, var(`--mantine-color-default-color`), transparent 88%);

Current state:
We can override` --mantine-color-blue-light-hover` and `--mantine-color-default-color` at a  scoped level.

Problem:
As the number of components grows, a single CSS variable might be used for different things — for example, as text color in <ComponentA> and background color in <ComponentB>. This causes conflicts.

Solution:
Use custom variables for each component.
This avoids conflicts and falls back to default colors if custom ones are not defined.

Example:

`background-color: var(`--vpi-menu-item-hover`, var(`--menu-item-hover`, var(`--mantine-color-gray-1`)));`
