### PR TITLE
SS-8897: use iframe settings in app builder for saved states and JSON

### DIFF
--- a/components/shapediver/viewport/ViewportIcons.tsx
+++ b/components/shapediver/viewport/ViewportIcons.tsx
@@ -72,21 +72,27 @@ const defaultStyleProps: ViewportIconsOptionalProps = {
 export default function ViewportIcons(
 	props: ViewportIconsProps & ViewportIconsOptionalProps,
 ) {
-	const {viewportId: _viewportId, namespace = "", ...rest} = props;
+	const {
+		viewportId: _viewportId,
+		namespace = "",
+		hideJsonMenu,
+		hideSavedStates,
+		...rest
+	} = props;
 
 	const {
 		style,
 		iconStyle,
 		fullscreenId,
 		enableHistoryButtons,
-		enableModelStateButtons,
-		enableImportExportButtons,
-		enableResetButton,
 		enableArBtn,
 		enableCamerasBtn,
 		enableFullscreenBtn,
 		enableZoomBtn,
-		enableHistoryMenuButton,
+		enableModelStateButtons: enableModelStateButtonsStyleProp,
+		enableImportExportButtons: enableImportExportButtonsStyleProp,
+		enableResetButton: enableResetButtonStyleProp,
+		enableHistoryMenuButton: enableHistoryMenuButtonStyleProp,
 		color,
 		colorDisabled,
 		variant,
@@ -206,6 +212,67 @@ export default function ViewportIcons(
 			iconsVisible,
 		],
 	);
+
+	/**
+	 * The reset button depends on the following:
+	 * - enableResetButtonStyleProp: if false, return false
+	 * - hideJsonMenu: if true, return false
+	 * otherwise, return true
+	 */
+	const enableResetButton = useMemo(() => {
+		if (enableResetButtonStyleProp === false) return false;
+		if (hideJsonMenu) return false;
+		return true;
+	}, [enableResetButtonStyleProp, hideJsonMenu]);
+
+	/**
+	 * The model state buttons depend on the following:
+	 * - enableModelStateButtonsStyleProp: if false, return false
+	 * - hideSavedStates: if true, return false
+	 * otherwise, return true
+	 */
+	const enableModelStateButtons = useMemo(() => {
+		if (enableModelStateButtonsStyleProp === false) return false;
+		if (hideSavedStates) return false;
+		return true;
+	}, [enableModelStateButtonsStyleProp, hideSavedStates]);
+
+	/**
+	 * The import/export buttons depend on the following:
+	 * - enableImportExportButtonsStyleProp: if false, return false
+	 * - hideJsonMenu: if true, return false
+	 * otherwise, return true
+	 */
+	const enableImportExportButtons = useMemo(() => {
+		if (enableImportExportButtonsStyleProp === false) return false;
+		if (hideJsonMenu) return false;
+		return true;
+	}, [enableImportExportButtonsStyleProp, hideJsonMenu]);
+
+	/**
+	 * The history menu button depends on the following:
+	 * - enableHistoryMenuButtonProp: if false, return false
+	 * - enableResetButton && enableImportExportButtons & enableModelStateButtons: if all false, return false
+	 * - otherwise, return true
+	 */
+	const enableHistoryMenuButton = useMemo(() => {
+		if (enableHistoryMenuButtonStyleProp === false) return false;
+		if (
+			enableResetButtonStyleProp === false &&
+			enableImportExportButtonsStyleProp === false &&
+			enableModelStateButtonsStyleProp === false
+		) {
+			return false;
+		}
+
+		return true;
+	}, [
+		enableHistoryMenuButtonStyleProp,
+		enableResetButtonStyleProp,
+		enableImportExportButtonsStyleProp,
+		enableModelStateButtonsStyleProp,
+	]);
+
 	const showHistoryDivider = useMemo(() => {
 		const hasViewerIcons =
 			(enableArBtn && isArEnabled) ||

--- a/hooks/shapediver/appbuilder/useResolveAppBuilderSettings.ts
+++ b/hooks/shapediver/appbuilder/useResolveAppBuilderSettings.ts
@@ -89,7 +89,9 @@ export default function useResolveAppBuilderSettings(
 						// setting in session
 						acceptRejectMode: model.settings.parameters_commit,
 						hideAttributeVisualization:
-							model.settings.hide_attribute_visualization,
+							model.settings.hide_attribute_visualization_iframe,
+						hideJsonMenu: model.settings.hide_json_menu_iframe,
+						hideSavedStates: model.settings.hide_json_menu_iframe,
 						...session,
 						ticket: model!.ticket!.ticket,
 						modelViewUrl: model!.backend_system!.model_view_url,
@@ -121,7 +123,11 @@ export default function useResolveAppBuilderSettings(
 							iframeData.model.settings?.parameters_commit,
 						hideAttributeVisualization:
 							iframeData.model.settings
-								?.hide_attribute_visualization,
+								?.hide_attribute_visualization_iframe,
+						hideJsonMenu:
+							iframeData.model.settings?.hide_json_menu_iframe,
+						hideSavedStates:
+							iframeData.model.settings?.hide_saved_states_iframe,
 						...session,
 						ticket: iframeData.ticket,
 						modelViewUrl: iframeData.model_view_url,

--- a/pages/appbuilder/AppBuilderPage.tsx
+++ b/pages/appbuilder/AppBuilderPage.tsx
@@ -328,7 +328,15 @@ export default function AppBuilderPage(props: Partial<Props>) {
 						{ViewportOverlayWrapper && (
 							<>
 								{ViewportIcons && (
-									<ViewportIcons namespace={namespace} />
+									<ViewportIcons
+										namespace={namespace}
+										hideJsonMenu={
+											controllerSession.hideJsonMenu
+										}
+										hideSavedStates={
+											controllerSession.hideSavedStates
+										}
+									/>
 								)}
 								<ViewportOverlayWrapper
 									position={OverlayPosition.BOTTOM_MIDDLE}

--- a/types/shapediver/appbuilder.ts
+++ b/types/shapediver/appbuilder.ts
@@ -697,6 +697,14 @@ export interface IAppBuilderSettingsSession extends SessionCreateDto {
 	 */
 	hideAttributeVisualization?: boolean;
 	/**
+	 * If the JSON menu should be hidden by default.
+	 */
+	hideJsonMenu?: boolean;
+	/**
+	 * If the saved states menu should be hidden by default.
+	 */
+	hideSavedStates?: boolean;
+	/**
 	 * Optional model state id.
 	 */
 	modelStateId?: string;

--- a/types/shapediver/viewportIcons.ts
+++ b/types/shapediver/viewportIcons.ts
@@ -19,6 +19,14 @@ export interface ViewportIconsProps {
 	 * Viewport ID
 	 */
 	viewportId?: string;
+	/**
+	 * If the JSON menu should be hidden by default.
+	 */
+	hideJsonMenu?: boolean;
+	/**
+	 * If the saved states menu should be hidden by default.
+	 */
+	hideSavedStates?: boolean;
 }
 
 export interface ViewportIconsOptionalProps {


### PR DESCRIPTION
https://shapediver.atlassian.net/browse/SS-8897

@snabela This works now as expected. 
One thing for you to check: hooks/shapediver/appbuilder/useResolveAppBuilderSettings.ts
In this file I now use just the iframe settings. For each of those settings there are two versions, non-iframe and iframe. I this the correct one for App Builder usage?

See this comment for the deployed example on a feature branch:
https://shapediver.atlassian.net/browse/SS-8897?focusedCommentId=44681