### PR TITLE
SS-8909/SS-8903: platform settings implementation

### DIFF
--- a/components/shapediver/appbuilder/AppBuilderFallbackContainerComponent.tsx
+++ b/components/shapediver/appbuilder/AppBuilderFallbackContainerComponent.tsx
@@ -56,7 +56,10 @@ export default function AppBuilderFallbackContainerComponent({
 				],
 			});
 		}
-		if (exports.length > 0 || outputs.length > 0) {
+		if (
+			(!settings?.hideExports && exports.length > 0) ||
+			(!settings?.hideDataOutputs && outputs.length > 0)
+		) {
 			tabProps.defaultValue = tabProps.defaultValue || "Exports";
 			tabProps.tabs.push({
 				name: "Exports",
@@ -64,8 +67,8 @@ export default function AppBuilderFallbackContainerComponent({
 				children: [
 					<ParametersAndExportsAccordionComponent
 						key={1}
-						exports={exports}
-						outputs={outputs}
+						exports={!settings?.hideExports ? exports : []}
+						outputs={!settings?.hideDataOutputs ? outputs : []}
 						namespace={namespace}
 					/>,
 				],
@@ -95,7 +98,7 @@ export default function AppBuilderFallbackContainerComponent({
 			}
 		}
 
-		if (showDesktopClientPanel) {
+		if (showDesktopClientPanel && !settings?.hideDesktopClients) {
 			tabProps.tabs.push({
 				name: "Stargate",
 				icon: IconTypeEnum.Network,

--- a/components/shapediver/viewport/ViewportIcons.tsx
+++ b/components/shapediver/viewport/ViewportIcons.tsx
@@ -76,7 +76,6 @@ export default function ViewportIcons(
 		viewportId: _viewportId,
 		namespace = "",
 		hideJsonMenu,
-		hideSavedStates,
 		...rest
 	} = props;
 
@@ -120,6 +119,10 @@ export default function ViewportIcons(
 				}
 
 				const ids = state.sessionDependency[namespace];
+				if (ids === undefined || ids.length === 0) {
+					return [];
+				}
+
 				return ids
 					.map((id) => state.parameterChanges[id])
 					.filter(Boolean);
@@ -228,14 +231,14 @@ export default function ViewportIcons(
 	/**
 	 * The model state buttons depend on the following:
 	 * - enableModelStateButtonsStyleProp: if false, return false
-	 * - hideSavedStates: if true, return false
+	 * - hideJsonMenu: if true, return false
 	 * otherwise, return true
 	 */
 	const enableModelStateButtons = useMemo(() => {
 		if (enableModelStateButtonsStyleProp === false) return false;
-		if (hideSavedStates) return false;
+		if (hideJsonMenu) return false;
 		return true;
-	}, [enableModelStateButtonsStyleProp, hideSavedStates]);
+	}, [enableModelStateButtonsStyleProp, hideJsonMenu]);
 
 	/**
 	 * The import/export buttons depend on the following:

--- a/hooks/shapediver/appbuilder/useResolveAppBuilderSettings.ts
+++ b/hooks/shapediver/appbuilder/useResolveAppBuilderSettings.ts
@@ -52,17 +52,27 @@ export default function useResolveAppBuilderSettings(
 
 		const sessions = await Promise.all(
 			settings.sessions.map(async (session) => {
+				const platformUrl =
+					session.platformUrl ?? getDefaultPlatformUrl();
+
 				if (!session.slug) {
 					if (!session.ticket || !session.modelViewUrl)
 						throw new Error(
 							"Session definition must either contain slug, or ticket and modelViewUrl.",
 						);
 
+					// We don't have a slug, but we have a ticket and modelViewUrl.
+					// This means that we try to get the corresponding settings from the viewer.
+					// As the viewer needs to be loaded to do this, we set a flag, so that these
+					// settings are appended once the viewer is loaded.
+					session.loadPlatformSettingsFromViewer =
+						shouldUsePlatform() &&
+						sdkRef!.platformUrl === platformUrl
+							? "platform"
+							: "iframe";
+
 					return session as IAppBuilderSettingsSession;
 				}
-
-				const platformUrl =
-					session.platformUrl ?? getDefaultPlatformUrl();
 
 				// in case we are running on the platform and the session is on the same platform,
 				// use a model get call to get ticket, modelViewUrl and token
@@ -94,9 +104,12 @@ export default function useResolveAppBuilderSettings(
 						// setting in session
 						acceptRejectMode: model.settings.parameters_commit,
 						hideAttributeVisualization:
-							model.settings.hide_attribute_visualization_iframe,
-						hideJsonMenu: model.settings.hide_json_menu_iframe,
-						hideSavedStates: model.settings.hide_json_menu_iframe,
+							model.settings.hide_attribute_visualization,
+						hideJsonMenu: model.settings.hide_json_menu,
+						hideSavedStates: model.settings.hide_saved_states,
+						hideDesktopClients: model.settings.hide_desktop_clients,
+						hideDataOutputs: model.settings.hide_data_outputs,
+						hideExports: model.settings.hide_exports,
 						...session,
 						ticket: model!.ticket!.ticket,
 						modelViewUrl: model!.backend_system!.model_view_url,
@@ -133,6 +146,10 @@ export default function useResolveAppBuilderSettings(
 							iframeData.model.settings?.hide_json_menu_iframe,
 						hideSavedStates:
 							iframeData.model.settings?.hide_saved_states_iframe,
+						hideDataOutputs:
+							iframeData.model.settings?.hide_data_outputs_iframe,
+						hideExports:
+							iframeData.model.settings?.hide_exports_iframe,
 						...session,
 						ticket: iframeData.ticket,
 						modelViewUrl: iframeData.model_view_url,

--- a/pages/appbuilder/AppBuilderPage.tsx
+++ b/pages/appbuilder/AppBuilderPage.tsx
@@ -203,6 +203,7 @@ export default function AppBuilderPage(props: Partial<Props>) {
 		hasAppBuilderOutput,
 		appBuilderData,
 		customParametersLoaded,
+		sessionSettings,
 	} = useSessionWithAppBuilder(
 		controllerSession,
 		settings?.appBuilderOverride,
@@ -263,7 +264,7 @@ export default function AppBuilderPage(props: Partial<Props>) {
 					exports={exportProps}
 					outputs={outputProps}
 					namespace={namespace}
-					settings={defaultSessionDto}
+					settings={sessionSettings}
 				/>
 			),
 		};

--- a/types/shapediver/appbuilder.ts
+++ b/types/shapediver/appbuilder.ts
@@ -750,6 +750,22 @@ export interface IAppBuilderSettingsSession extends SessionCreateDto {
 	 */
 	hideSavedStates?: boolean;
 	/**
+	 * If the desktop clients should be hidden by default.
+	 */
+	hideDesktopClients?: boolean;
+	/**
+	 * If the data outputs should be hidden by default.
+	 */
+	hideDataOutputs?: boolean;
+	/**
+	 * If the exports should be hidden by default.
+	 */
+	hideExports?: boolean;
+	/**
+	 * In case we cannot connect to the platform, load settings from the viewer, if they were stored there. (default: undefined)
+	 */
+	loadPlatformSettingsFromViewer?: "platform" | "iframe";
+	/**
 	 * Optional model state id.
 	 */
 	modelStateId?: string;


### PR DESCRIPTION
https://shapediver.atlassian.net/browse/SS-8909
https://shapediver.atlassian.net/browse/SS-8903

Two tasks in one as they were very related. 
I know use the settings as specified in the first task.

If only ticket and modelViewUrl is provided, I use the settings stored on the viewer.

Can be tested on branch `SS-8909` by using models from the dev platform where we now also store these settings in the viewer as a fallback.