### PR TITLE
SS-9071: implemented model state image support

### DIFF
--- a/components/shapediver/appbuilder/actions/AppBuilderActionAddToCartComponent.tsx
+++ b/components/shapediver/appbuilder/actions/AppBuilderActionAddToCartComponent.tsx
@@ -25,7 +25,7 @@ export default function AppBuilderActionAddToCartComponent(props: Props) {
 		price,
 		description,
 		includeImage,
-		//image, // TODO use image defined by export of href
+		image,
 		includeGltf,
 		parameterNamesToInclude,
 		parameterNamesToExclude,
@@ -53,6 +53,7 @@ export default function AppBuilderActionAddToCartComponent(props: Props) {
 			parameterNamesToInclude,
 			parameterNamesToExclude,
 			includeImage,
+			image,
 			undefined, // <-- custom data
 			includeGltf,
 		);

--- a/components/shapediver/appbuilder/actions/AppBuilderActionCreateModelStateComponent.tsx
+++ b/components/shapediver/appbuilder/actions/AppBuilderActionCreateModelStateComponent.tsx
@@ -24,7 +24,7 @@ export default function AppBuilderActionCreateModelStateComponent(
 		tooltip,
 		namespace,
 		includeImage,
-		//image, // TODO use image defined by export of href
+		image,
 		includeGltf,
 		parameterNamesToInclude,
 		parameterNamesToExclude,
@@ -43,6 +43,7 @@ export default function AppBuilderActionCreateModelStateComponent(
 			parameterNamesToInclude,
 			parameterNamesToExclude,
 			includeImage,
+			image,
 			undefined, // <-- custom data
 			includeGltf,
 		);

--- a/components/shapediver/appbuilder/actions/AppBuilderActionSetBrowserLocationComponent.tsx
+++ b/components/shapediver/appbuilder/actions/AppBuilderActionSetBrowserLocationComponent.tsx
@@ -64,7 +64,8 @@ export default function AppBuilderActionSetBrowserLocationComponent(
 			const {modelStateId} = await createModelState(
 				undefined, // <-- parameterNamesToInclude: use default according to the theme
 				undefined, // <-- parameterNamesToExclude: use default according to the theme
-				true, // <-- includeImage,
+				false, // <-- includeImage,
+				undefined,
 				undefined, // <-- custom data
 				false, // <-- includeGltf,
 			);

--- a/components/shapediver/viewport/buttons/HistoryMenuButton.tsx
+++ b/components/shapediver/viewport/buttons/HistoryMenuButton.tsx
@@ -34,7 +34,8 @@ export default function HistoryMenuButton({
 		const {modelStateId} = await createModelState(
 			undefined, // <-- parameterNamesToInclude: use default according to the theme
 			undefined, // <-- parameterNamesToExclude: use default according to the theme
-			true, // <-- includeImage,
+			false, // <-- includeImage,
+			undefined, // <-- image
 			undefined, // <-- custom data
 			false, // <-- includeGltf
 		);

--- a/hooks/shapediver/parameters/valueSources/useModelStateSources.ts
+++ b/hooks/shapediver/parameters/valueSources/useModelStateSources.ts
@@ -31,7 +31,7 @@ export function useModelStateSources(props: {
 				const {
 					updateUrl = false,
 					includeImage,
-					// image, // TODO use image defined by export of href
+					image,
 					includeGltf,
 					parameterNamesToInclude,
 					parameterNamesToExclude,
@@ -41,6 +41,7 @@ export function useModelStateSources(props: {
 					parameterNamesToInclude,
 					parameterNamesToExclude,
 					includeImage,
+					image,
 					undefined,
 					includeGltf,
 				).then(({modelStateId}) => {

--- a/hooks/shapediver/useCreateModelState.ts
+++ b/hooks/shapediver/useCreateModelState.ts
@@ -1,8 +1,11 @@
 import {useViewportId} from "@AppBuilderShared/hooks/shapediver/viewer/useViewportId";
+import {useShapeDiverStoreParameters} from "@AppBuilderShared/store/useShapeDiverStoreParameters";
 import {useShapeDiverStoreSession} from "@AppBuilderShared/store/useShapeDiverStoreSession";
 import {useShapeDiverStoreViewportAccessFunctions} from "@AppBuilderShared/store/useShapeDiverStoreViewportAccessFunctions";
+import {IAppBuilderImageRef} from "@AppBuilderShared/types/shapediver/appbuilder";
 import {QUERYPARAM_MODELSTATEID} from "@AppBuilderShared/types/shapediver/queryparams";
 import {MantineThemeComponent, useProps} from "@mantine/core";
+import {ISessionApi} from "@shapediver/viewer.session";
 import {useCallback} from "react";
 import {useShallow} from "zustand/react/shallow";
 
@@ -53,6 +56,12 @@ export function useCreateModelState(props: Props) {
 			sessionApi: state.sessions[sessionId],
 		})),
 	);
+	const {exportsPerSession} = useShapeDiverStoreParameters(
+		useShallow((state) => ({
+			exportsPerSession: state.exportStores,
+		})),
+	);
+
 	const {getScreenshot, convertToGlTF} =
 		useShapeDiverStoreViewportAccessFunctions(
 			useShallow((state) => ({
@@ -68,6 +77,7 @@ export function useCreateModelState(props: Props) {
 			parameterNamesToInclude = parameterNamesToIncludeDefault,
 			parameterNamesToExclude = parameterNamesToExcludeDefault,
 			includeImage?: boolean,
+			image?: IAppBuilderImageRef | undefined,
 			data?: Record<string, any>,
 			includeGltf?: boolean,
 		): Promise<{
@@ -114,19 +124,57 @@ export function useCreateModelState(props: Props) {
 					{} as {[key: string]: unknown},
 				);
 
-			// we need to create a screenshot before the model state
-			// as the function signature of createModelState does not allow to pass a promise for the screenshot
-			// Jira-task: https://shapediver.atlassian.net/browse/SS-8363
-			const screenshot =
-				includeImage && getScreenshot
-					? await getScreenshot()
-					: undefined;
+			// create the image for the model state (if includeImage is true)
+			// if an image ref is provided, use that
+			// if the image ref points to an export, try to get the export from the session and request it
+			// otherwise, if no image ref is provided, use getScreenshot (if available)
+			// if includeImage is false or undefined, do not create an image
+			let modelStateImage: string | undefined = undefined;
+			if (includeImage) {
+				if (image) {
+					if (image.href) {
+						modelStateImage = image.href;
+					} else if (image.export) {
+						const sessionForExport =
+							exportsPerSession[
+								image.export.sessionId || sessionId
+							];
+						if (sessionForExport) {
+							const exp = Object.values(sessionForExport).find(
+								(e) => {
+									const def = e.getState().definition;
+									return (
+										def.id === image.export?.name ||
+										def.name === image.export?.name ||
+										def.displayname === image.export?.name
+									);
+								},
+							);
+							if (exp) {
+								const exportResult = await exp
+									.getState()
+									.actions.request();
+								if (
+									exportResult.content &&
+									exportResult.content[0] &&
+									exportResult.content[0].href
+								) {
+									modelStateImage =
+										exportResult.content[0].href;
+								}
+							}
+						}
+					}
+				} else if (getScreenshot) {
+					modelStateImage = await getScreenshot();
+				}
+			}
 
 			const modelStateId = sessionApi
 				? await sessionApi.createModelState(
 						parameterValues,
 						true, // <-- omitSessionParameterValues
-						screenshot,
+						modelStateImage, // <-- screenshot or provided image
 						data, // <-- custom data
 						includeGltf && convertToGlTF
 							? async () => convertToGlTF()
@@ -143,10 +191,10 @@ export function useCreateModelState(props: Props) {
 
 			return {
 				modelStateId,
-				screenshot,
+				screenshot: modelStateImage,
 				modelViewUrl,
 				modelStateImageUrl:
-					screenshot && modelStateId
+					modelStateImage && modelStateId
 						? modelViewUrl +
 							`/api/v2/model-state/${modelStateId}/image`
 						: undefined,
@@ -162,6 +210,8 @@ export function useCreateModelState(props: Props) {
 		},
 		[
 			sessionApi,
+			sessionId,
+			exportsPerSession,
 			getScreenshot,
 			convertToGlTF,
 			parameterNamesToIncludeDefault,

--- a/hooks/shapediver/useKeyBindings.ts
+++ b/hooks/shapediver/useKeyBindings.ts
@@ -28,7 +28,8 @@ export function useKeyBindings(props: Props) {
 		const {modelStateId, screenshot} = await createModelState(
 			undefined, // <-- parameterNamesToInclude: use default according to the theme
 			undefined, // <-- parameterNamesToExclude: use default according to the theme
-			true, // <-- includeImage,
+			false, // <-- includeImage,
+			undefined, // <-- image
 			undefined, // <-- custom data
 			false, // <-- includeGltf
 		);


### PR DESCRIPTION
https://shapediver.atlassian.net/browse/SS-9071

@snabela There are some cases that I would like you to have a look at:

1. Whenever a model state is created without any inputs, I now don't include the screenshot. I don't know why we would, do you agree? examples: `AppBuilderActionSetBrowserLocationComponent`, `HistoryMenuButton`, `useKeyBindings` 
2. In the `createModelState` function, the session api is currently directly used for the parameters (https://github.com/shapediver/AppBuilderShared/blob/35b423a8c90c883cd3c17a2dbd7a7687b8c6410d/hooks/shapediver/useCreateModelState.ts#L98) but not for the exports (https://github.com/shapediver/AppBuilderShared/blob/35b423a8c90c883cd3c17a2dbd7a7687b8c6410d/hooks/shapediver/useCreateModelState.ts#L138). I think it makes sense to do it the same way for both, do you agree?
3. I currently just pass through the `href` from the export, is that enough or should I fetch it and then create a dataurl from the blob?