### PR TITLE
SS-9698: Keep anchor state

### DIFF
--- a/entities/viewport-anchor/ui/ViewportAnchor2d.tsx
+++ b/entities/viewport-anchor/ui/ViewportAnchor2d.tsx
@@ -109,6 +109,23 @@ export default function ViewportAnchor2d(
 	}, [canvasWidth, canvasHeight]);
 
 	/**
+	 * Recalculate anchor position when portal content size changes
+	 * (e.g. stack navigation, parameter-driven widget updates).
+	 */
+	useEffect(() => {
+		const el = portalRef.current;
+		if (!el || !showContent) return;
+
+		const observer = new ResizeObserver(() => {
+			initializedRef.current = false;
+			setUpdatePositionCalculation((prev) => prev + 1);
+		});
+		observer.observe(el);
+
+		return () => observer.disconnect();
+	}, [showContent, portalUpdate]);
+
+	/**
 	 * The main use effect for the anchor.
 	 * It creates a new HTMLElementAnchorCustomData instance
 	 * and adds it to the scene tree.

--- a/entities/viewport/model/useViewportAnchors.tsx
+++ b/entities/viewport/model/useViewportAnchors.tsx
@@ -64,7 +64,7 @@ export function useViewportAnchors(props: Props): JSX.Element[] {
 
 				anchors.push(
 					<ViewportAnchor3d.component
-						key={JSON.stringify(container)}
+						key={container.props.id}
 						id={container.props.id}
 						location={container.props.location}
 						justification={container.props.justification}
@@ -124,7 +124,7 @@ export function useViewportAnchors(props: Props): JSX.Element[] {
 
 				anchors.push(
 					<ViewportAnchor2d.component
-						key={JSON.stringify(container)}
+						key={container.props.id}
 						id={container.props.id}
 						location={container.props.location}
 						justification={container.props.justification}


### PR DESCRIPTION
https://shapediver.atlassian.net/browse/SS-9698?focusedCommentId=75363

Issue: The stack widget inside of Anchor resets state to initial on child elements update.