### PR TITLE
SS-9800: fix undo button for custom parameters

### DIFF
--- a/entities/parameter/model/useShapeDiverStoreParameters.ts
+++ b/entities/parameter/model/useShapeDiverStoreParameters.ts
@@ -6,6 +6,7 @@ import {
 	IShapeDiverOutput,
 	IShapeDiverOutputDefinition,
 } from "@AppBuilderLib/entities/output/config/output";
+import {CUSTOM_SESSION_ID_POSTFIX} from "@AppBuilderLib/features/appbuilder/model/useAppBuilderCustomParameters";
 import {
 	EventActionEnum,
 	IEventTracking,
@@ -1712,7 +1713,20 @@ export const useShapeDiverStoreParameters =
 					skipHistory?: boolean,
 				) {
 					const {batchParameterValueUpdate} = get();
-					await batchParameterValueUpdate(state, skipHistory);
+					const primaryState: ISessionsHistoryState = {};
+					const namespaces = Object.keys(state);
+
+					for (const namespace of namespaces) {
+						if (!namespace.endsWith(CUSTOM_SESSION_ID_POSTFIX))
+							primaryState[namespace] = state[namespace];
+					}
+
+					// Normal parameter updates only customize the primary/model
+					// namespaces. Dependent generic namespaces (like *_appbuilder)
+					// are derived from those updates and should resync from the
+					// restored model/AppBuilder input instead of being restored as an
+					// additional parallel state source.
+					await batchParameterValueUpdate(primaryState, skipHistory);
 				},
 
 				async restoreHistoryStateFromIndex(index: number) {

--- a/features/appbuilder/model/useAppBuilderCustomParameters.ts
+++ b/features/appbuilder/model/useAppBuilderCustomParameters.ts
@@ -24,6 +24,19 @@ interface Props {
 	acceptRejectMode: IAcceptRejectModeSelector | boolean | undefined;
 }
 
+const parseCustomParameterValues = (value: unknown) => {
+	if (typeof value !== "string" || value.length === 0) return {};
+
+	try {
+		const parsed = JSON.parse(value);
+		return parsed && typeof parsed === "object"
+			? (parsed as {[key: string]: any})
+			: {};
+	} catch {
+		return {};
+	}
+};
+
 /**
  * This hook registers custom parameters and UI elements defined by a data output component
  * of the model named "AppBuilder". Updates of the custom parameter values are fed back to the model as JSON into
@@ -90,21 +103,41 @@ export function useAppBuilderCustomParameters(props: Props) {
 		})),
 	);
 
+	const restoredCustomParameterValues = useMemo(
+		() =>
+			parseCustomParameterValues(
+				appBuilderParam?.state.execValue ??
+					appBuilderParam?.state.uiValue,
+			),
+		[appBuilderParam?.state.execValue, appBuilderParam?.state.uiValue],
+	);
+
 	// set the default values of the custom parameters whenever the
 	// custom parameter definitions change
 	useEffect(() => {
 		if (appBuilderData?.parameters) {
 			appBuilderData.parameters.forEach((p) => {
+				const hasRestoredValue = Object.prototype.hasOwnProperty.call(
+					restoredCustomParameterValues,
+					p.id,
+				);
+
+				// Prefer the value currently stored in the AppBuilder input parameter.
+				// This is important during undo/redo: history restores the AppBuilder
+				// input before the AppBuilder output recreates dynamic custom
+				// parameters. Without this, newly recreated custom parameters fall
+				// back to the fresh output defaults and overwrite the restored state.
+				defaultCustomParameterValues.current[p.id] = hasRestoredValue
+					? restoredCustomParameterValues[p.id]
+					: (p.value ?? p.defval);
+
 				// If a "value" is given as part of the custom parameter definition,
-				// we use it to define the default value of the custom parameter.
-				defaultCustomParameterValues.current[p.id] =
-					p.value ?? p.defval;
-				// If a "value" is given as part of the custom parameter definition,
+				// or a value was restored through the AppBuilder input parameter,
 				// AND if a value has already been set for the custom parameter,
 				// we remove this current value of the custom parameter
 				// (thereby overriding the current value with the given one).
 				if (
-					p.value !== undefined &&
+					(hasRestoredValue || p.value !== undefined) &&
 					p.id in customParameterValues.current
 				)
 					delete customParameterValues.current[p.id];
@@ -114,7 +147,7 @@ export function useAppBuilderCustomParameters(props: Props) {
 		return () => {
 			defaultCustomParameterValues.current = {};
 		};
-	}, [appBuilderData]);
+	}, [appBuilderData, restoredCustomParameterValues]);
 
 	// executor function for changes of custom parameter values
 	const executor = useCallback<IGenericParameterExecutor>(
@@ -271,10 +304,19 @@ export function useAppBuilderCustomParameters(props: Props) {
 		() =>
 			(appBuilderData?.parameters ?? []).map((p) => {
 				const {value, ...rest} = p;
+				const hasRestoredValue = Object.prototype.hasOwnProperty.call(
+					restoredCustomParameterValues,
+					p.id,
+				);
 
-				return {definition: rest, value};
+				return {
+					definition: rest,
+					value: hasRestoredValue
+						? restoredCustomParameterValues[p.id]
+						: value,
+				};
 			}),
-		[appBuilderData?.parameters],
+		[appBuilderData?.parameters, restoredCustomParameterValues],
 	);
 
 	// define custom parameters and an execution callback for them


### PR DESCRIPTION
https://shapediver.atlassian.net/browse/SS-9800

When using undo/redo on a model with instances, custom parameter values (material selections, vase sizes) were reset to their output defaults instead of being restored to the correct previous state. History restore was restoring all namespaces in one parallel batch, including `*_appbuilder` dynamic custom-parameter namespaces. But these namespaces are derived from the AppBuilder output and their parameter stores only exist after the model customization completes.

History undo/redo now follows the normal parameter update path:

1. Restore only primary/model namespaces: *_appbuilder namespaces are excluded from direct restore since they are derived state, not source state.
2. Repopulate derived custom parameters from the restored input: When the AppBuilder output recreates dynamic custom parameters after a model update (including undo), the hook now reads the restored values from the AppBuilder input and uses them instead of falling back to fresh output defaults.