### PR TITLE
SS-9800: implemented context aware parameter history

### DIFF
--- a/entities/parameter/config/shapediverStoreParameters.ts
+++ b/entities/parameter/config/shapediverStoreParameters.ts
@@ -299,6 +299,13 @@ export interface IShapeDiverStoreParameters {
 	readonly historyIndex: number;
 
 	/**
+	 * Transient derived namespace state captured during history restore.
+	 * This is used to rehydrate derived UI-only namespaces without replaying
+	 * them as executable history entries.
+	 */
+	readonly pendingHistoryDerivedState: ISessionsHistoryState;
+
+	/**
 	 * Add parameter and export stores for all parameters and exports of the session.
 	 * CAUTION: Repeated calls will be ignored. Use removeSession to remove a session first before
 	 * calling addSession again for the same session.
@@ -512,6 +519,18 @@ export interface IShapeDiverStoreParameters {
 	 * all history entries after the current index are removed.
 	 */
 	readonly pushHistoryState: (state: ISessionsHistoryState) => IHistoryEntry;
+
+	/**
+	 * Replace the transient derived namespace state used during history restore.
+	 */
+	readonly setPendingHistoryDerivedState: (
+		state: ISessionsHistoryState,
+	) => void;
+
+	/**
+	 * Clear transient derived namespace state for one namespace or all namespaces.
+	 */
+	readonly clearPendingHistoryDerivedState: (namespace?: string) => void;
 
 	/**
 	 * Restore the state of parameter values from the given history state.

--- a/entities/parameter/model/useShapeDiverStoreParameters.ts
+++ b/entities/parameter/model/useShapeDiverStoreParameters.ts
@@ -6,6 +6,7 @@ import {
 	IShapeDiverOutput,
 	IShapeDiverOutputDefinition,
 } from "@AppBuilderLib/entities/output/config/output";
+import {CUSTOM_SESSION_ID_POSTFIX} from "@AppBuilderLib/features/appbuilder/model/useAppBuilderCustomParameters";
 import {
 	EventActionEnum,
 	IEventTracking,
@@ -774,6 +775,7 @@ export const useShapeDiverStoreParameters =
 				preExecutionHooks: {},
 				history: [],
 				historyIndex: -1,
+				pendingHistoryDerivedState: {},
 				hasParameterDisablingOthers: false,
 
 				removeChanges: (namespace: string) => {
@@ -1707,12 +1709,70 @@ export const useShapeDiverStoreParameters =
 					return entry;
 				},
 
+				setPendingHistoryDerivedState(state: ISessionsHistoryState) {
+					set(
+						() => ({
+							pendingHistoryDerivedState: state,
+						}),
+						false,
+						"setPendingHistoryDerivedState",
+					);
+				},
+
+				clearPendingHistoryDerivedState(namespace?: string) {
+					const {pendingHistoryDerivedState} = get();
+					if (!namespace) {
+						set(
+							() => ({
+								pendingHistoryDerivedState: {},
+							}),
+							false,
+							"clearPendingHistoryDerivedState",
+						);
+						return;
+					}
+
+					if (!(namespace in pendingHistoryDerivedState)) return;
+
+					const remainingState: ISessionsHistoryState = {};
+					Object.keys(pendingHistoryDerivedState).forEach((id) => {
+						if (id !== namespace)
+							remainingState[id] = pendingHistoryDerivedState[id];
+					});
+
+					set(
+						() => ({
+							pendingHistoryDerivedState: remainingState,
+						}),
+						false,
+						"clearPendingHistoryDerivedState",
+					);
+				},
+
 				async restoreHistoryState(
 					state: ISessionsHistoryState,
 					skipHistory?: boolean,
 				) {
-					const {batchParameterValueUpdate} = get();
-					await batchParameterValueUpdate(state, skipHistory);
+					const {
+						batchParameterValueUpdate,
+						setPendingHistoryDerivedState,
+					} = get();
+					const primaryState: ISessionsHistoryState = {};
+					const derivedState: ISessionsHistoryState = {};
+
+					for (const namespace of Object.keys(state)) {
+						if (namespace.endsWith(CUSTOM_SESSION_ID_POSTFIX))
+							derivedState[namespace] = state[namespace];
+						else primaryState[namespace] = state[namespace];
+					}
+
+					// Derived AppBuilder custom-parameter namespaces are stored in
+					// history for rehydration, but should not be replayed as
+					// executable namespaces during undo/redo. Stash them temporarily
+					// so the AppBuilder custom-parameter hook can rehydrate its local
+					// stores once after the controller/session restore completes.
+					setPendingHistoryDerivedState(derivedState);
+					await batchParameterValueUpdate(primaryState, skipHistory);
 				},
 
 				async restoreHistoryStateFromIndex(index: number) {

--- a/features/appbuilder/model/useAppBuilderCustomParameters.ts
+++ b/features/appbuilder/model/useAppBuilderCustomParameters.ts
@@ -82,11 +82,19 @@ export function useAppBuilderCustomParameters(props: Props) {
 		setPreExecutionHook,
 		removePreExecutionHook,
 		batchParameterValueUpdate,
+		pendingHistoryDerivedState,
+		clearPendingHistoryDerivedState,
+		parameterStores,
 	} = useShapeDiverStoreParameters(
 		useShallow((state) => ({
 			setPreExecutionHook: state.setPreExecutionHook,
 			removePreExecutionHook: state.removePreExecutionHook,
 			batchParameterValueUpdate: state.batchParameterValueUpdate,
+			pendingHistoryDerivedState:
+				state.pendingHistoryDerivedState[namespaceAppBuilder],
+			clearPendingHistoryDerivedState:
+				state.clearPendingHistoryDerivedState,
+			parameterStores: state.parameterStores[namespaceAppBuilder],
 		})),
 	);
 
@@ -286,6 +294,42 @@ export function useAppBuilderCustomParameters(props: Props) {
 		executor,
 		namespace,
 	);
+
+	useEffect(() => {
+		if (
+			!loaded ||
+			!appBuilderData?.parameters ||
+			!pendingHistoryDerivedState ||
+			Object.keys(pendingHistoryDerivedState).length === 0
+		)
+			return;
+
+		appBuilderData.parameters.forEach((p) => {
+			const hasRestoredValue = Object.prototype.hasOwnProperty.call(
+				pendingHistoryDerivedState,
+				p.id,
+			);
+			if (!hasRestoredValue) return;
+
+			defaultCustomParameterValues.current[p.id] =
+				pendingHistoryDerivedState[p.id];
+			if (p.id in customParameterValues.current)
+				delete customParameterValues.current[p.id];
+
+			const store = parameterStores?.[p.id];
+			const {actions} = store?.getState() ?? {};
+			actions?.setUiAndExecValue(pendingHistoryDerivedState[p.id]);
+		});
+
+		clearPendingHistoryDerivedState(namespaceAppBuilder);
+	}, [
+		appBuilderData,
+		clearPendingHistoryDerivedState,
+		loaded,
+		namespaceAppBuilder,
+		parameterStores,
+		pendingHistoryDerivedState,
+	]);
 
 	// Don't block parameters history initialization if there are no custom parameters
 	if (parameterDefinitions.length === 0) {


### PR DESCRIPTION
https://shapediver.atlassian.net/browse/SS-9800

### What changed                                                                           
                                                                                            
 - During history restore, only real/controller session namespaces are executed             
 - *_appbuilder history state is kept temporarily and used only to rehydrate the derived    
   custom parameter stores                                                                  
 - Rehydration updates the custom parameter UI/store values directly, without executing     
   their executor again                                                                     
                                                                                            
 ### Why                                                                                    
                                                                                            
 History stores a snapshot of resulting state, not the original single user action.         
 So undo/redo should restore the source-of-truth session state and then rehydrate derived   
 AppBuilder UI state, instead of rerunning the full live custom-parameter execution path.